### PR TITLE
rubocopをCIでまわす

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,22 @@
+name: Static Analysis
+
+on: pull_request
+
+jobs:
+  rubocop:
+    name: Run rubocop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+
+      - name: Run rubocop
+        uses: reviewdog/action-rubocop@v1
+        with:
+          rubocop_version: 1.24.0
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          fail_on_error: true


### PR DESCRIPTION
https://github.com/chiroruxx/aiit-student-profile/issues/9 PR作成時に自動でlintしてくれるように設定しました。
エラーがあると reviewdog がコメントでワンワンしてくれます。
ワンワンしてくれてる様子は https://github.com/chiroruxx/aiit-student-profile/pull/17 で見れます。

エラーが解消されるまではマージボタンは押せない（はず）です。

参考: [reviewdog/action-rubocop](https://github.com/reviewdog/action-rubocop)