### PR TITLE
[issue-6] feature/6/user profile css

### DIFF
--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -22,7 +22,7 @@ class UserProfilesController < ApplicationController
     # @user_profile = current_user.build_user_profile(profile_params)
     @user_profile = @user.build_user_profile(profile_params)
     if @user_profile.save
-      render 'edit'
+      redirect_to user_profiles_path
     else
       render 'new'
     end

--- a/app/javascript/packs/user_profiles.scss
+++ b/app/javascript/packs/user_profiles.scss
@@ -1,59 +1,57 @@
 // background-color
 .bg-palegreen {
-    --bs-bg-opacity: 1;
-    background-color: #EDF6E5;
+  --bs-bg-opacity: 1;
+  background-color: #edf6e5;
 }
 
 // Google Material Icons
 // デフォルトだとアイコンが浮いてしまうため
 .material-icons {
-    vertical-align: middle;
+  vertical-align: middle;
 }
 
 // body
 body {
-    font-family: 'Noto Sans JP', sans-serif;
-    a {
-        color: black;
-    }
+  font-family: "Noto Sans JP", sans-serif;
+  a {
+    color: black;
+  }
 }
 
 // profile list
 .users {
-    list-style: none;
-    margin: 0;
-    li {
-      overflow: auto;
-      margin: 10px 0;
-      box-shadow: 3px 4px 5px grey;
-      .user-info {
-        position: fixed;
-        padding: 10px;
-        .username > a {
-          text-decoration: none;
-          font-size: 26px;
-          font-weight: bold;
-        }
-        .major_subject {
-          font-size: 12px;
-          .material-icons {
-              font-size: 13px;
-              padding: 2px;
-
-          }
-        }
-        .other {
-          display: block;
-          padding: 3px 0;
-          font-size: 12px;
-          font-weight: bold;
+  list-style: none;
+  margin: 0;
+  li {
+    overflow: auto;
+    margin: 10px 0;
+    box-shadow: 3px 4px 5px grey;
+    .user-info {
+      position: fixed;
+      padding: 10px;
+      .username > a {
+        text-decoration: none;
+        font-size: 26px;
+        font-weight: bold;
+      }
+      .major_subject {
+        font-size: 12px;
+        .material-icons {
+          font-size: 13px;
+          padding: 2px;
         }
       }
-
+      .other {
+        display: block;
+        padding: 3px 0;
+        font-size: 12px;
+        font-weight: bold;
+      }
     }
-    .account-icon {
-      font-size: 90px;
-    }
+  }
+  .account-icon {
+    font-size: 90px;
+  }
 }
 
 // profile registration/edit
@@ -65,7 +63,15 @@ body {
 
 .user_profile {
   /* form */
-  input[type="text"], textarea, select {
+  div.subtitle {
+    margin-top: 15px;
+    font-size: 26px;
+    font-weight: bold;
+  }
+
+  input[type="text"],
+  textarea,
+  select {
     border: 1px solid #bbb;
     width: 100%;
     margin-bottom: 15px;
@@ -77,8 +83,8 @@ body {
   }
 
   .form-required:after {
-    content: '*';
-    color: #F38BA0;
+    content: "*";
+    color: #f38ba0;
   }
 
   .checkbox {
@@ -91,36 +97,46 @@ body {
   }
 
   .field_with_errors {
-    .form-controls {
-      border-color: #F38BA0;
-      color: #F38BA0;
+    .form-control {
+      border-color: #f38ba0;
+      color: #f38ba0;
       -webkit-box-shadow: inset 0 1px 1px rgb(0 0 0 / 8%);
       box-shadow: inset 0 1px 1px rgb(0 0 0 / 8%);
     }
+  }
+
+  .error_message {
+    color: #f38ba0;
+  }
+
+  .btn {
+    margin-top: 15px;
+    background-color: #B5EAEA;
+    border: none;
   }
 }
 
 // header
 header {
-    box-shadow: 3px 4px 5px grey;
-    .container {
-        > a {
-            font-size: 2.25rem;
-            line-height: 2.5rem;
-            text-decoration: none;
-            font-weight: bold;
-          }
-        .material-icons {
-          font-size: 1rem;
-        }
-        nav > ul {
-            font-size: 1rem;
-            line-height: 1.5rem;
-        }
+  box-shadow: 3px 4px 5px grey;
+  .container {
+    > a {
+      font-size: 2.25rem;
+      line-height: 2.5rem;
+      text-decoration: none;
+      font-weight: bold;
     }
+    .material-icons {
+      font-size: 1rem;
+    }
+    nav > ul {
+      font-size: 1rem;
+      line-height: 1.5rem;
+    }
+  }
 }
 
 // footer
 footer {
-    border-top: 1px solid #eaeaea;
-  }
+  border-top: 1px solid #eaeaea;
+}

--- a/app/javascript/packs/user_profiles.scss
+++ b/app/javascript/packs/user_profiles.scss
@@ -56,6 +56,50 @@ body {
     }
 }
 
+// profile registration/edit
+@mixin box_sizing {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.user_profile {
+  /* form */
+  input[type="text"], textarea, select {
+    border: 1px solid #bbb;
+    width: 100%;
+    margin-bottom: 15px;
+    @include box_sizing;
+  }
+
+  input {
+    height: auto !important;
+  }
+
+  .form-required:after {
+    content: '*';
+    color: #F38BA0;
+  }
+
+  .checkbox {
+    margin-top: -10px;
+    margin-bottom: 10px;
+    span {
+      margin-left: 20px;
+      font-weight: normal;
+    }
+  }
+
+  .field_with_errors {
+    .form-controls {
+      border-color: #F38BA0;
+      color: #F38BA0;
+      -webkit-box-shadow: inset 0 1px 1px rgb(0 0 0 / 8%);
+      box-shadow: inset 0 1px 1px rgb(0 0 0 / 8%);
+    }
+  }
+}
+
 // header
 header {
     box-shadow: 3px 4px 5px grey;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,10 +3,15 @@
     <%= link_to "AIIT Student Profile", user_profiles_path %>
     <nav>
       <ul class="nav navbar-nav navbar-right">
-        <li>
-        <%= link_to register_path do %>
-            <span class="material-icons">edit</span>
-            プロフを編集する
+        <% if not ( params[:controller]=='user_profiles' && %w(new edit).include?(params[:action]) ) %>
+          <li>
+          <%= link_to register_path do %>
+              <span class="material-icons">edit</span>
+              プロフを編集する
+          <% end %>
+          </li>
+        <% else %>
+          <li></li>
         <% end %>
       </ul>
     </nav>

--- a/app/views/user_profiles/_form.html.erb
+++ b/app/views/user_profiles/_form.html.erb
@@ -1,28 +1,51 @@
 <%= form_with(model: @user_profile, local: true) do |f| %>
   <div class="user_profile">
     <div>
-      <h1>基本情報</h1>
+      <div class="subtitle">
+        <span class="material-icons">insert_drive_file</span>
+        基本情報
+      </div>
       <%= f.label :name, '名前', class: 'form-required' %>
-      <%= f.text_field :name, class: 'form-controls' %>
+      <%= f.text_field :name, class: 'form-control' %>
+      <% if @user_profile.errors.include?(:name) %>
+        <% @user_profile.errors.full_messages_for(:name).each do |msg| %>
+          <p class="error_message"><%= msg %></p>
+        <% end %>
+      <% end %>
 
       <%= f.label :name_kana, 'ふりがな' %>
-      <%= f.text_field :name_kana %>
+      <%= f.text_field :name_kana, class: 'form-control' %>
 
       <%= f.label :email, 'メールアドレス', class: 'form-required' %>
-      <%= f.text_field :email, class: 'form-controls' %>
+      <%= f.text_field :email, class: 'form-control' %>
+      <% if @user_profile.errors.include?(:email) %>
+        <% @user_profile.errors.full_messages_for(:email).each do |msg| %>
+          <p class="error_message"><%= msg %></p>
+        <% end %>
+      <% end %>
 
       <%= f.label :major_subject, 'コース', class: 'form-required' %>
       <%= f.select(:major_subject, 
                   @major_subject.map{ |value| [value, value] },
                   { :prompt => '選択してください' },
-                  { :class => 'form-controls' })
+                  { :class => 'form-control' })
                   %>
+      <% if @user_profile.errors.include?(:major_subject) %>
+        <% @user_profile.errors.full_messages_for(:major_subject).each do |msg| %>
+          <p class="error_message"><%= msg %></p>
+        <% end %>
+      <% end %>
 
       <%= f.label :started, '入学年', class: 'form-required' %>
-      <%= f.text_field :started, class: 'form-controls' %>
+      <%= f.text_field :started, class: 'form-control' %>
+      <% if @user_profile.errors.include?(:started) %>
+        <% @user_profile.errors.full_messages_for(:started).each do |msg| %>
+          <p class="error_message"><%= msg %></p>
+        <% end %>
+      <% end %>
 
       <%= f.label :other, '自己紹介' %>
-      <%= f.text_area :other, placeholder: '入力...' %>
+      <%= f.text_area :other, placeholder: '入力...', class: 'form-control' %>
 
       <div>
       プロフィール画像
@@ -31,33 +54,39 @@
     </div>
 
     <div>
-      <h1>個人プロフィール</h1>
+      <div class="subtitle">
+        <span class="material-icons">person</span>
+        個人プロフィール
+      </div>
       <div>
         <%= f.label :nickname, 'ニックネーム' %>
-        <%= f.text_field :nickname %>
+        <%= f.text_field :nickname, class: 'form-control' %>
 
         <%= f.label :work, '仕事' %>
-        <%= f.text_field :work, placeholder: '入力...' %>
+        <%= f.text_field :work, placeholder: '入力...', class: 'form-control' %>
 
         <%= f.label :hobby, '趣味' %>
-        <%= f.text_area :hobby %>
+        <%= f.text_area :hobby, class: 'form-control' %>
 
         <%= f.label :favorite_food, '好きな食べ物' %>
-        <%= f.text_field :favorite_food %>
+        <%= f.text_field :favorite_food, class: 'form-control' %>
 
         <%= f.label :hated_food, '嫌いな食べ物' %>
-        <%= f.text_field :hated_food %>
+        <%= f.text_field :hated_food, class: 'form-control' %>
       </div>
     </div>
 
     <div>
-      <h1>学校プロフィール</h1>
+      <div class="subtitle">
+        <span class="material-icons">school</span>
+        学校プロフィール
+      </div>
       <div>
         <%= f.label :background, '入学した経緯' %>
-        <%= f.text_area :background, placeholder: '入力...' %>
+        <%= f.text_area :background, placeholder: '入力...', class: 'form-control' %>
 
         <%= f.label :pbl, '入りたいPBL' %>
-        <%= f.text_field :pbl %>
+        <%= f.text_field :pbl, class: 'form-control' %>
 
         <%= f.label :user_profile_subjects, '受講した科目' %>
         <%= f.collection_check_boxes :subject_ids, @subjects, :id, :name do |b| %>
@@ -71,8 +100,8 @@
       </div>
     </div>
 
-    <div>
-      <%= f.submit '保存' %>
+    <div class="col-6 mx-auto d-flex justify-content-center">
+      <%= f.submit '保存する', class: 'btn btn-primary btn-lg' %>
     </div>
   </div>
 <% end %>

--- a/app/views/user_profiles/_form.html.erb
+++ b/app/views/user_profiles/_form.html.erb
@@ -1,112 +1,78 @@
-<% if @user_profile.errors.any? %>
-  <div>
-    <div class="alert alert-danger">
-      <ul>
-        <% @user_profile.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  </div>
-<% end %>
-
-<% if @user_profile.id %>
-user profile id: <%= @user_profile.id %>
-<% end %>
-
 <%= form_with(model: @user_profile, local: true) do |f| %>
-  <div>
-    <h1>基本情報</h1>
+  <div class="user_profile">
     <div>
-      <p><%= f.label :name, '名前' %></p>
-      <p><%= f.text_field :name %></p>
-    </div>
+      <h1>基本情報</h1>
+      <%= f.label :name, '名前', class: 'form-required' %>
+      <%= f.text_field :name, class: 'form-controls' %>
 
-    <div>
-      <p><%= f.label :name_kana, 'ふりがな' %></p>
-      <p><%= f.text_field :name_kana %></p>
-    </div>
+      <%= f.label :name_kana, 'ふりがな' %>
+      <%= f.text_field :name_kana %>
 
-    <div>
-      <p><%= f.label :email, 'メールアドレス' %></p>
-      <p><%= f.text_field :email %></p>
-    </div>
+      <%= f.label :email, 'メールアドレス', class: 'form-required' %>
+      <%= f.text_field :email, class: 'form-controls' %>
 
-    <div>
-      <p><%= f.label :major_subject, 'コース' %></p>
-      <p><%= f.select :major_subject, 
+      <%= f.label :major_subject, 'コース', class: 'form-required' %>
+      <%= f.select(:major_subject, 
                   @major_subject.map{ |value| [value, value] },
-                  :prompt => '選択してください' %></p>
+                  { :prompt => '選択してください' },
+                  { :class => 'form-controls' })
+                  %>
+
+      <%= f.label :started, '入学年', class: 'form-required' %>
+      <%= f.text_field :started, class: 'form-controls' %>
+
+      <%= f.label :other, '自己紹介' %>
+      <%= f.text_area :other, placeholder: '入力...' %>
+
+      <div>
+      プロフィール画像
+      ...
+      </div>
     </div>
 
     <div>
-      <p><%= f.label :started, '入学年' %></p>
-      <p><%= f.text_field :started %></p>
+      <h1>個人プロフィール</h1>
+      <div>
+        <%= f.label :nickname, 'ニックネーム' %>
+        <%= f.text_field :nickname %>
+
+        <%= f.label :work, '仕事' %>
+        <%= f.text_field :work, placeholder: '入力...' %>
+
+        <%= f.label :hobby, '趣味' %>
+        <%= f.text_area :hobby %>
+
+        <%= f.label :favorite_food, '好きな食べ物' %>
+        <%= f.text_field :favorite_food %>
+
+        <%= f.label :hated_food, '嫌いな食べ物' %>
+        <%= f.text_field :hated_food %>
+      </div>
     </div>
 
     <div>
-      <p><%= f.label :other, '自己紹介' %></p>
-      <p><%= f.text_area :other, placeholder: '入力...' %></p>
+      <h1>学校プロフィール</h1>
+      <div>
+        <%= f.label :background, '入学した経緯' %>
+        <%= f.text_area :background, placeholder: '入力...' %>
+
+        <%= f.label :pbl, '入りたいPBL' %>
+        <%= f.text_field :pbl %>
+
+        <%= f.label :user_profile_subjects, '受講した科目' %>
+        <%= f.collection_check_boxes :subject_ids, @subjects, :id, :name do |b| %>
+          <div>
+            <%= b.label class:"checkbox" do %>
+              <%= b.check_box %>
+              <span><%= b.text %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     </div>
 
     <div>
-      <p>プロフィール画像</p>
-      <p>...</p>
+      <%= f.submit '保存' %>
     </div>
   </div>
-
-  <div>
-    <h1>個人プロフィール</h1>
-    <div>
-      <p><%= f.label :nickname, 'ニックネーム' %></p>
-      <p><%= f.text_field :nickname %></p>
-    </div>
-
-    <div>
-      <p><%= f.label :work, '仕事' %></p>
-      <p><%= f.text_field :work, placeholder: '入力...' %></p>
-    </div>
-
-    <div>
-      <p><%= f.label :hobby, '趣味' %></p>
-      </p><%= f.text_area :hobby %></p>
-    </div>
-
-    <div>
-      <p><%= f.label :favorite_food, '好きな食べ物' %></p>
-      <p><%= f.text_field :favorite_food %></p>
-    </div>
-
-    <div>
-      <p><%= f.label :hated_food, '嫌いな食べ物' %></p>
-      <p><%= f.text_field :hated_food %></p>
-    </div>
-  </div>
-
-  <div>
-    <h1>学校プロフィール</h1>
-    <div>
-      <p><%= f.label :background, '入学した経緯' %></p>
-      <p><%= f.text_area :background, placeholder: '入力...' %></p>
-    </div>
-
-    <div>
-      <p><%= f.label :pbl, '入りたいPBL' %></p>
-      <p><%= f.text_field :pbl %></p>
-    </div>
-
-    <div>
-      <p><%= f.label :user_profile_subjects, '受講した科目' %></p>
-      <p><%= f.collection_check_boxes :subject_ids,
-                                   @subjects, 
-                                   :id, 
-                                   :name
-      %></p>
-    </div>
-  </div>
-
-  <div>
-    <%= f.submit '保存' %>
-  </div>
-  
 <% end %>

--- a/app/views/user_profiles/edit.html.erb
+++ b/app/views/user_profiles/edit.html.erb
@@ -1,1 +1,5 @@
-<%= render 'form', user_profile: @user_profile %>
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= render 'form', user_profile: @user_profile %>
+  </div>
+</div>

--- a/app/views/user_profiles/new.html.erb
+++ b/app/views/user_profiles/new.html.erb
@@ -1,1 +1,5 @@
-<%= render 'form', user_profile: @user_profile %>
+<div class="row">
+  <div class="col-md-6 offset-md-3">
+    <%= render 'form', user_profile: @user_profile %>
+  </div>
+</div>

--- a/test/integration/profile_registration_test.rb
+++ b/test/integration/profile_registration_test.rb
@@ -40,6 +40,6 @@ class ProfileRegistrationTest < ActionDispatch::IntegrationTest
         }
       }
     end
-    assert_template 'user_profiles/edit'
+    assert_redirected_to user_profiles_path
   end
 end


### PR DESCRIPTION
#6 

- プロフィール入力フォームにCSSを適用
- 保存が成功したら、リストに飛ばす

# 画面イメージ
<img width="1262" alt="Screen Shot 2022-01-06 at 1 35 11" src="https://user-images.githubusercontent.com/37922005/148259568-384655d1-db7b-4c8e-977b-6dd9f5c19d50.png">

<img width="1104" alt="Screen Shot 2022-01-06 at 1 55 20" src="https://user-images.githubusercontent.com/37922005/148259596-501c8109-5bc9-42f8-997c-aade4b4d1b41.png">

<img width="1262" alt="Screen Shot 2022-01-06 at 1 44 28" src="https://user-images.githubusercontent.com/37922005/148259623-03427d9f-f3e7-4511-aab7-33a762e63b4e.png">
