### PR TITLE
[issue-6] プロフィール保存時エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.5'
 
+# Localize display messages
+gem 'rails-i18n', '~> 6.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.4'
 # Use postgresql as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.1.4.4)
       actionpack (= 6.1.4.4)
       activesupport (= 6.1.4.4)
@@ -241,6 +244,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4)
   rails-controller-testing (= 1.0.4)
+  rails-i18n (~> 6.0)
   rubocop-rails
   sass-rails (>= 6)
   selenium-webdriver

--- a/app/javascript/styles/user_profiles.scss
+++ b/app/javascript/styles/user_profiles.scss
@@ -94,7 +94,7 @@
   }
 
   .field_with_errors {
-    .form-control {
+    .form-control, .form-select {
       border-color: $accent-strong;
       color: $accent-strong;
       -webkit-box-shadow: inset 0 1px 1px rgb(0 0 0 / 8%);

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,7 +5,7 @@
     </a>
     <nav>
       <ul class="header_menu nav navbar-nav navbar-right">
-        <% if not ( params[:controller]=='user_profiles' && %w(new edit).include?(params[:action]) ) %>
+        <% if not ( params[:controller]=='user_profiles' && %w(new edit create).include?(params[:action]) ) %>
           <li>
           <%= link_to register_path do %>
               <span class="material-icons">edit</span>

--- a/app/views/user_profiles/_form.html.erb
+++ b/app/views/user_profiles/_form.html.erb
@@ -32,7 +32,7 @@
       <%= f.select(:major_subject, 
                   @major_subject.map{ |value| [value, value] },
                   { :prompt => '選択してください' },
-                  { :class => 'form-control' })
+                  { :class => 'form-select' })
                   %>
       <% if @user_profile.errors.include?(:major_subject) %>
         <div class="error_message_container">

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,10 @@ module ProfileApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+    config.active_model.i18n_customize_full_message = true
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,206 @@
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+    abbr_month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    order:
+      - :year
+      - :month
+      - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ""
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ""
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ""
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -106,18 +106,18 @@ ja:
       month: 月
       year: 年
   errors:
-    format: "%{attribute}%{message}"
+    format: "%{attribute}%{message}。"
     messages:
-      accepted: を受諾してください
+      accepted: に同意してください
       blank: を入力してください
       confirmation: と%{attribute}の入力が一致しません
       empty: を入力してください
       equal_to: は%{count}にしてください
       even: は偶数にしてください
-      exclusion: は予約されています
+      exclusion: は選択できません
       greater_than: は%{count}より大きい値にしてください
       greater_than_or_equal_to: は%{count}以上の値にしてください
-      inclusion: は一覧にありません
+      inclusion: は選択できません
       invalid: は不正な値です
       less_than: は%{count}より小さい値にしてください
       less_than_or_equal_to: は%{count}以下の値にしてください

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -17,3 +17,8 @@ ja:
               blank: "%{attribute}を入力してください"
               empty: "%{attribute}を入力してください"
               invalid: 有効な%{attribute}を入力してください
+            major_subject:
+              format: "%{attribute}%{message}"
+              blank: を選択してください
+              empty: を選択してください
+           

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,19 @@
+ja:
+  activerecord:
+    models:
+      user_profile: プロフ
+    attributes:
+      user_profile:
+        name: 名前
+        email: メールアドレス
+        major_subject: コース
+        started: 入学年
+    errors:
+      models:
+        user_profile:
+          attributes:
+            email:
+              format: "%{message}"
+              blank: "%{attribute}を入力してください"
+              empty: "%{attribute}を入力してください"
+              invalid: 有効な%{attribute}を入力してください

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,7 +1,7 @@
 ja:
   activerecord:
     models:
-      user_profile: プロフ
+      user_profile: プロフィール
     attributes:
       user_profile:
         name: 名前
@@ -13,12 +13,12 @@ ja:
         user_profile:
           attributes:
             email:
-              format: "%{message}"
+              format: "%{message}。"
               blank: "%{attribute}を入力してください"
               empty: "%{attribute}を入力してください"
               invalid: 有効な%{attribute}を入力してください
             major_subject:
-              format: "%{attribute}%{message}"
+              format: "%{attribute}%{message}。"
               blank: を選択してください
               empty: を選択してください
            


### PR DESCRIPTION
#6 アップデート

- Railsのi18n APIにより、エラーメッセージを日本語化しました。
- 保存が失敗した時、ヘッダーに"プロフを編集する"ではなく、"他のプロフを見る"を表示するように調整しました。

参考：
https://railsguides.jp/i18n.html
https://github.com/svenfuchs/rails-i18n

<img width="1188" alt="Screen Shot 2022-01-07 at 10 39 55" src="https://user-images.githubusercontent.com/37922005/148477391-d9390748-6bd7-4985-ba12-d0660be12588.png">