### PR TITLE
プロフィール登録ページ・テストを修正

### DIFF
--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -3,7 +3,7 @@
 # Controller for create and edit UserProfile
 class UserProfilesController < ApplicationController
   before_action :set_info, only: %i[new create edit]
-  # before_action ... , only: %i[index new create edit update] # logged in?
+  before_action :signed_in, only: %i[index new create show edit update]
   # before_action ... , only: %i[edit update] # correct user?
 
   def index
@@ -11,21 +11,16 @@ class UserProfilesController < ApplicationController
   end
 
   def new
-    @user = User.new
-    # @user_profile = current_user.build_user_profile
-    @user_profile = @user.build_user_profile
+    if current_user.is_registered?
+      redirect_to user_profiles_path # temp
+    else
+      @user_profile = current_user.build_user_profile
+      @user_profile.name = current_user.name
+    end
   end
 
   def create
-    @user = User.new({
-                       name: 'test',
-                       provider: 'test',
-                       uid: 'test',
-                       email: 'test'
-                     })
-    @user.save
-    # @user_profile = current_user.build_user_profile(profile_params)
-    @user_profile = @user.build_user_profile(profile_params)
+    @user_profile = current_user.build_user_profile(profile_params)
     if @user_profile.save
       redirect_to user_profiles_path
     else
@@ -38,9 +33,11 @@ class UserProfilesController < ApplicationController
   end
 
   def edit
-    @user = User.last
-    # @user_profile = current_user.user_profile
-    @user_profile = @user.user_profile
+    if current_user.is_registered?
+      @user_profile = current_user.user_profile
+    else
+      redirect_to register_path
+    end
   end
 
   def update; end

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -11,11 +11,11 @@ class UserProfilesController < ApplicationController
   end
 
   def new
-    if current_user.profile_registered?
-      redirect_to user_profiles_path # temp
-    else
+    if !current_user.profile_registered?
       @user_profile = current_user.build_user_profile
       @user_profile.name = current_user.name
+    else
+      redirect_to user_profiles_path # temp
     end
   end
 

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -11,7 +11,7 @@ class UserProfilesController < ApplicationController
   end
 
   def new
-    if current_user.is_registered?
+    if current_user.profile_registered?
       redirect_to user_profiles_path # temp
     else
       @user_profile = current_user.build_user_profile
@@ -33,7 +33,7 @@ class UserProfilesController < ApplicationController
   end
 
   def edit
-    if current_user.is_registered?
+    if current_user.profile_registered?
       @user_profile = current_user.user_profile
     else
       redirect_to register_path

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -11,10 +11,11 @@ class UserProfilesController < ApplicationController
   end
 
   def new
-    @user_profile = current_user.build_user_profile
-    @user_profile.name = current_user.name
     if current_user.profile_registered?
       redirect_to user_profiles_path # temp
+    else
+      @user_profile = current_user.build_user_profile
+      @user_profile.name = current_user.name
     end
   end
 

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -13,10 +13,10 @@ class UserProfilesController < ApplicationController
   def new
     if current_user.profile_registered?
       redirect_to user_profiles_path # temp
-    else
-      @user_profile = current_user.build_user_profile
-      @user_profile.name = current_user.name
+      return
     end
+    @user_profile = current_user.build_user_profile
+    @user_profile.name = current_user.name
   end
 
   def create

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -11,10 +11,9 @@ class UserProfilesController < ApplicationController
   end
 
   def new
-    if !current_user.profile_registered?
-      @user_profile = current_user.build_user_profile
-      @user_profile.name = current_user.name
-    else
+    @user_profile = current_user.build_user_profile
+    @user_profile.name = current_user.name
+    if current_user.profile_registered?
       redirect_to user_profiles_path # temp
     end
   end

--- a/app/javascript/styles/user_profiles.scss
+++ b/app/javascript/styles/user_profiles.scss
@@ -123,6 +123,10 @@
     margin-bottom: 0;
   }
 
+  &--img {
+    display: block;
+  }
+
   .btn {
     margin-top: 1rem;
     font-weight: 500;

--- a/app/javascript/styles/user_profiles.scss
+++ b/app/javascript/styles/user_profiles.scss
@@ -123,7 +123,7 @@
     margin-bottom: 0;
   }
 
-  &--img {
+  &_img {
     display: block;
   }
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Subject < ApplicationRecord
-  has_many :user_profile_subjects
+  has_many :user_profile_subjects, dependent: :destroy
   has_many :user_profile, through: :user_profile_subjects
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
     end
   end
 
-  def is_registered?
-    !self.user_profile.nil?
+  def profile_registered?
+    !user_profile.nil?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@
 
 # User is a class that inherits from ApplicationRecord
 class User < ApplicationRecord
-  has_one :user_profile
+  has_one :user_profile, dependent: :destroy
   class << self
     def find_or_create_from_auth_hash(auth_hash)
       user_params = user_params_from_auth_hash(auth_hash)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,4 +23,8 @@ class User < ApplicationRecord
       }
     end
   end
+
+  def is_registered?
+    !self.user_profile.nil?
+  end
 end

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -2,7 +2,8 @@
 
 # model for UserProfile
 class UserProfile < ApplicationRecord
-  belongs_to :user, dependent: :destroy
+  belongs_to :user
+  validates :user_id, presence: true
   has_many :user_profile_subjects, dependent: :destroy
   has_many :subjects, through: :user_profile_subjects
 

--- a/app/views/user_profiles/_form.html.erb
+++ b/app/views/user_profiles/_form.html.erb
@@ -55,10 +55,8 @@
       <%= f.label :other, '自己紹介' %>
       <%= f.text_area :other, placeholder: "こんにちは！\n情報アーキテクトとプロジェクトマネジメントに興味があります。\nよろしくおねがいします。", rows: 5, class: 'form-control' %>
 
-      <div>
-      プロフィール画像
-      ...
-      </div>
+      <label>プロフィール画像</label>
+      <%= image_tag current_user.image, class: 'user_profile--img' %>
     </div>
 
     <div class="field_group">

--- a/app/views/user_profiles/_form.html.erb
+++ b/app/views/user_profiles/_form.html.erb
@@ -56,7 +56,7 @@
       <%= f.text_area :other, placeholder: "こんにちは！\n情報アーキテクトとプロジェクトマネジメントに興味があります。\nよろしくおねがいします。", rows: 5, class: 'form-control' %>
 
       <label>プロフィール画像</label>
-      <%= image_tag current_user.image, class: 'user_profile--img' %>
+      <%= image_tag current_user.image, class: 'user_profile_img' %>
     </div>
 
     <div class="field_group">

--- a/test/controllers/user_profiles_controller_test.rb
+++ b/test/controllers/user_profiles_controller_test.rb
@@ -40,11 +40,4 @@ class UserProfilesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to root_path
   end
-
-  test 'assoicated user_profile should be destroyed' do
-    user = users(:one)
-    assert_difference 'UserProfile.count', -1 do
-      user.destroy
-    end
-  end
 end

--- a/test/controllers/user_profiles_controller_test.rb
+++ b/test/controllers/user_profiles_controller_test.rb
@@ -40,4 +40,11 @@ class UserProfilesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to root_path
   end
+
+  test 'assoicated user_profile should be destroyed' do
+    user = users(:one)
+    assert_difference 'UserProfile.count', -1 do
+      user.destroy
+    end
+  end
 end

--- a/test/fixtures/subjects.yml
+++ b/test/fixtures/subjects.yml
@@ -5,7 +5,9 @@
 # below each fixture, per the syntax in the comments below
 #
 one:
+  id: 1
   name: IoT開発特論
 
 two:
+  id: 2
   name: OSS特論

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -35,4 +35,8 @@ four:
 <% (100..121).each do |idx| %> 
 user_<%= idx %>:
   id: <%= idx  %>
+  provider: Google
+  name: 'mockuser'
+  uid: 12345678910,
+  email: mock@example.com
 <% end %>

--- a/test/integration/profile_registration_test.rb
+++ b/test/integration/profile_registration_test.rb
@@ -5,52 +5,52 @@ require 'test_helper'
 class ProfileRegistrationTest < ActionDispatch::IntegrationTest
   setup do
     OmniAuth.config.test_mode = true
-    sign_in
-
-    @user = users(:three)
   end
 
   teardown do
     OmniAuth.config.test_mode = false
   end
 
+  test 'should redirect register when not signed in' do
+    sign_out
+    get register_path
+    assert_not signed_in?
+    assert_redirected_to root_path
+  end
+
   test 'unsuccessful registration' do
+    sign_in
     # login and do not have user_profile
-    if signed_in?
-      get register_path
-      assert_template 'user_profiles/new'
-      assert_no_difference 'UserProfile.count' do
-        post user_profiles_path, params: {
-          user_profile: {
-            user_id: 3,
-            name: '',
-            email: '',
-            major_subject: '',
-            started: ''
-          }
+    get register_path
+    assert_template 'user_profiles/new'
+    assert_no_difference 'UserProfile.count' do
+      post user_profiles_path, params: {
+        user_profile: {
+          name: '',
+          email: '',
+          major_subject: '',
+          started: ''
         }
-      end
-      assert_template 'user_profiles/new'
+      }
     end
+    assert_template 'user_profiles/new'
   end
 
   test 'successful registration' do
+    sign_in
     # login and do not have user_profile
-    if signed_in?
-      get register_path
-      assert_template 'user_profiles/new'
-      assert_difference 'UserProfile.count', 1 do
-        post user_profiles_path, params: {
-          user_profile: {
-            user_id: 3,
-            name: 'man',
-            email: 'man@man.com',
-            major_subject: '情報アーキテクチャ',
-            started: '2021'
-          }
+    get register_path
+    assert_template 'user_profiles/new'
+    assert_difference 'UserProfile.count', 1 do
+      post user_profiles_path, params: {
+        user_profile: {
+          name: 'mockuser',
+          email: 'mock@example.com',
+          major_subject: '情報アーキテクチャ',
+          started: '2021'
         }
-      end
-      assert_redirected_to user_profiles_path
+      }
     end
+    assert_redirected_to user_profiles_path
   end
 end

--- a/test/models/subject_test.rb
+++ b/test/models/subject_test.rb
@@ -3,7 +3,10 @@
 require 'test_helper'
 
 class SubjectTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'assoicated user_profile_subject should be destroyed' do
+    subject = subjects(:one)
+    assert_difference 'UserProfileSubject.count', -1 do
+      subject.destroy
+    end
+  end
 end

--- a/test/models/user_profile_test.rb
+++ b/test/models/user_profile_test.rb
@@ -71,7 +71,7 @@ class UserProfileTest < ActiveSupport::TestCase
 
   # work, backgroud, hobby, other
 
-  test 'assoicated profile_subjects should be destroyed' do
+  test 'assoicated user_profile_subjects should be destroyed' do
     @user_profile.save
     @user_profile.user_profile_subjects.create!(subject_id: @subject.id)
     assert_difference 'UserProfileSubject.count', -1 do

--- a/test/models/user_profile_test.rb
+++ b/test/models/user_profile_test.rb
@@ -4,8 +4,8 @@ require 'test_helper'
 
 class UserProfileTest < ActiveSupport::TestCase
   def setup
-    @user = user(:one)
-    @user_profile = user_profiles(:one)
+    @user = users(:one)
+    @user_profile = @user.user_profile
     @subject = subjects(:one)
   end
 
@@ -73,7 +73,6 @@ class UserProfileTest < ActiveSupport::TestCase
 
   test 'assoicated profile_subjects should be destroyed' do
     @user_profile.save
-    @subject.save
     @user_profile.user_profile_subjects.create!(subject_id: @subject.id)
     assert_difference 'UserProfileSubject.count', -1 do
       @user_profile.destroy

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,7 +3,10 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'assoicated user_profile should be destroyed' do
+    user = users(:one)
+    assert_difference 'UserProfile.count', -1 do
+      user.destroy
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,6 +50,10 @@ module ActiveSupport
       get '/auth/google_oauth2/callback'
     end
 
+    def sign_out
+      Rails.application.env_config['omniauth.auth'] = nil
+    end
+
     def signed_in?
       !Rails.application.env_config['omniauth.auth'].nil?
     end


### PR DESCRIPTION
# 概要
PR #42 からのブランチです。

#50 Googleログイン後、プロフィール登録に関するコードを修正しました。

# やったこと
- user_profiles_controller.rb、user.rb： 
  - #25 のダミーコードを削除
  - ログイン後、current_userを使用
  - 登録に関するメソッドを追加
- user_profiles.scss、_form.html.erb：
  - プロフィール画像に対してcssを更新
- user_profile.rb：
  - 「dependent: :destroy」の設定が間違ったので、修正
- subject.rb、user.rb：
  - 「dependent: :destroy」の設定を追加
- users.yml、subjects.yml：
  - テストを更新
- profile_registration_test.rb、user_profile_test.rb：
  - 登録のテストを更新
- subject_test.rb、user_test.rb：
  - 「dependent: :destroy」に対するテストを追加
- test_helper.rb：
  - 登録のテストのため、sign_outを追加

# やっていないこと
プロフィール更新・編集に関するコードとテスト
