### PR TITLE
詳細ページでユーザの画像を表示する

### DIFF
--- a/app/views/user_profiles/show.html.erb
+++ b/app/views/user_profiles/show.html.erb
@@ -1,12 +1,11 @@
 <% content_for(:title, @profile.name + ' さんのプロフィール') %>
 
 <div class="base_profile">
-  <%#= if @profile.has_image %>
-  <%# ログイン後に差し替える %>
-  <img src="https://1.bp.blogspot.com/-3YfJ5FDIfB0/Wn1V7_0bdfI/AAAAAAABKGc/NJMDAsrSGBEkWEpaxBjBujsXHqOXEx3pACLcBGAs/s400/hyoujou_shinda_me_man.png" alt="" class="base_profile__photo">
-  <%# else %>
-  <%# <span class="base_profile__photo material-icons">account_box</span> %>
-  <%# endif %>
+  <% if @profile.user.image.present? %>
+    <img src="<%= @profile.user.image %>" alt="" class="base_profile__photo">
+  <% else %>
+    <span class="base_profile__photo material-icons">account_box</span>
+  <% end %>
   <div class="base_profile__info">
     <% if @profile.name_kana.present? %>
       <span><%=  @profile.name_kana  %></span>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -10,6 +10,7 @@ one:
   name: Taro Yamada
   uid: 100000000000000000000
   email: taro@example.com
+  image: https://example.com
 
 two:
   id: 2

--- a/test/integration/user_profiles_show_test.rb
+++ b/test/integration/user_profiles_show_test.rb
@@ -20,7 +20,7 @@ class UserProfilesShowTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template 'user_profiles/show'
 
-    # assert_match profile.image, @response.body
+    assert_match profile.user.image, @response.body
     assert_match profile.name, @response.body
     assert_match profile.name_kana, @response.body
     assert_match profile.nickname, @response.body


### PR DESCRIPTION
# 概要
https://github.com/chiroruxx/aiit-student-profile/issues/49

詳細ページで画像を表示する際にユーザ認証時の画像を使用するように修正した。

# やったこと
- 詳細ページのプロフ画像を users.image から取得するようにした
  - 今はないが、もし user_profile に image カラムを追加した際にはここも修正する必要がある

# やっていないこと
一覧ページのプロフ画像の差し替え

# 見てほしいところ・注意してほしいところなど
