### PR TITLE
ログインページの実装

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,6 +6,6 @@ class HomeController < ApplicationController
   skip_before_action :signed_in, only: :index
 
   def index
-    redirect_to user_profiles_path if current_user
+    redirect_to profiles_path if current_user
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,7 @@
 
 # HomeController is a class that inherits from ApplicationController
 class HomeController < ApplicationController
+  layout 'full'
   skip_before_action :signed_in, only: :index
 
   def index; end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,5 +5,7 @@ class HomeController < ApplicationController
   layout 'full'
   skip_before_action :signed_in, only: :index
 
-  def index; end
+  def index
+    redirect_to user_profiles_path if current_user
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
   def create
     if (user = User.find_or_create_from_auth_hash(auth_hash))
       sign_in user
-      return redirect_to user_profiles_path
+      return redirect_to profiles_path
     end
     redirect_to root_path
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,7 @@ class SessionsController < ApplicationController
   def create
     if (user = User.find_or_create_from_auth_hash(auth_hash))
       sign_in user
+      return redirect_to user_profiles_path
     end
     redirect_to root_path
   end

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -3,4 +3,5 @@
 @import "base";
 @import "layout";
 @import "error";
+@import "top";
 @import "user_profiles";

--- a/app/javascript/styles/base.scss
+++ b/app/javascript/styles/base.scss
@@ -2,6 +2,7 @@
 a {
   color: $text-color;
   text-decoration: underline;
+  -webkit-tap-highlight-color:rgba(0,0,0,0);
 
   &:visited {
     color: $text-color;

--- a/app/javascript/styles/top.scss
+++ b/app/javascript/styles/top.scss
@@ -1,0 +1,41 @@
+.top {
+  display: flex;
+  flex-flow: nowrap column;
+  justify-content: center;
+  height: 100%;
+
+  &__container {
+    height: 20rem;
+    display: flex;
+    flex-flow: nowrap column;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__title {
+    font-size: 4rem;
+    font-weight: bold;
+  }
+
+  &__description {
+    text-align: center;
+  }
+}
+
+.top_button {
+  background-color: $accent-strong;
+  border: none;
+  box-shadow: 0 4px 4px $shadow;
+  color: $text-button;
+
+  &:hover {
+    background-color: $accent-strong;
+    color: $text-button;
+    text-decoration: none;
+  }
+
+  &:visited {
+    color: $text-button;
+    text-decoration: none;
+  }
+}

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,10 @@
-<h1>Home#index</h1>
-<p>Find me in app/views/home/index.html.erb</p>
+<div class="top">
+  <div class="top__container container">
+    <h1 class="top__title">AIIT Student Profile</h1>
+    <p class="top__description">
+      AIIT Student Profile は簡単にプロフィールを作成できるサービスです。<br>
+      グループワークでの自己紹介タイムで簡単にわかりやすく自己紹介ができます。
+    </p>
+    <a class="btn btn-primary btn-lg top_button" href="/auth/google_oauth2" role="button" data-method="post">さっそくログインする</a>
+  </div>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,26 +5,20 @@
     </a>
     <nav class="navbar navbar-expand-lg">
       <ul class="header_menu navbar-nav">
-        <% if current_user %>
-          <% unless params[:controller] == 'user_profiles' && params[:action] == 'index' %>
-            <li class="nav-item">
-              <%= link_to profiles_path, class: 'nav-link' do %>
-                <span class="material-icons">list</span>
-                他のプロフを見る
-              <% end %>
-            </li>
-          <% end %>
-          <% unless params[:controller] == 'user_profiles' && %w(new edit create).include?(params[:action]) %>
-           <li class="nav-item">
-             <%= link_to profiles_edit_path, class: 'nav-link' do %>
-               <span class="material-icons">edit</span>
-               プロフを編集する
-             <% end %>
-            </li>
-          <% end %>
-        <% else %>
+        <% unless params[:controller] == 'user_profiles' && params[:action] == 'index' %>
           <li class="nav-item">
-            <%= link_to 'Sign in with Google', '/auth/google_oauth2', method: :post %>
+            <%= link_to profiles_path, class: 'nav-link' do %>
+              <span class="material-icons">list</span>
+              他のプロフを見る
+            <% end %>
+          </li>
+        <% end %>
+        <% unless params[:controller] == 'user_profiles' && %w(new edit create).include?(params[:action]) %>
+         <li class="nav-item">
+           <%= link_to profiles_edit_path, class: 'nav-link' do %>
+             <span class="material-icons">edit</span>
+             プロフを編集する
+           <% end %>
           </li>
         <% end %>
       </ul>

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -3,4 +3,23 @@
 require 'test_helper'
 
 class HomeControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    OmniAuth.config.test_mode = true
+  end
+
+  teardown do
+    OmniAuth.config.test_mode = false
+  end
+
+  test 'should get index' do
+    get root_path
+    assert_response :success
+  end
+
+  test 'should redirect to list if logged in' do
+    sign_in
+    get root_path
+    assert_redirected_to user_profiles_path
+  end
+
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -19,6 +19,6 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
   test 'should redirect to list if logged in' do
     sign_in
     get root_path
-    assert_redirected_to user_profiles_path
+    assert_redirected_to profiles_path
   end
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -21,5 +21,4 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get root_path
     assert_redirected_to user_profiles_path
   end
-
 end

--- a/test/controllers/session_controller_test.rb
+++ b/test/controllers/session_controller_test.rb
@@ -17,7 +17,7 @@ class SessionControllerTest < ActionDispatch::IntegrationTest
 
     get '/auth/:provider/callback'
 
-    assert_redirected_to root_path
+    assert_redirected_to profiles_path
   end
 
   test 'Save user data if user have not logged in' do

--- a/test/integration/login_test.rb
+++ b/test/integration/login_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LoginTest < ActionDispatch::IntegrationTest
+  setup do
+    OmniAuth.config.test_mode = true
+    Rails.application.env_config['omniauth.auth'] = nil
+    setup_omniauth_mock
+    Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
+  end
+
+  teardown do
+    OmniAuth.config.test_mode = false
+  end
+
+  test 'login flow' do
+    get root_path
+    assert_response :success
+
+    post '/auth/google_oauth2'
+    assert_response :redirect
+    assert_redirected_to '/auth/google_oauth2/callback'
+
+    follow_redirect!
+    assert_response :redirect
+    assert_redirected_to user_profiles_path
+
+    follow_redirect!
+    assert_response :success
+  end
+end

--- a/test/integration/login_test.rb
+++ b/test/integration/login_test.rb
@@ -24,7 +24,7 @@ class LoginTest < ActionDispatch::IntegrationTest
 
     follow_redirect!
     assert_response :redirect
-    assert_redirected_to user_profiles_path
+    assert_redirected_to profiles_path
 
     follow_redirect!
     assert_response :success


### PR DESCRIPTION
# 概要
fixed #59 

ログインページを実装しました。

![image](https://user-images.githubusercontent.com/9111423/149953546-7ab42ab2-c604-42d5-931f-72837896c743.png)

# やったこと
- ログインページのUIの実装しました。
- ログイン済みの場合はログインページではなく一覧ページを表示するようにしました。
- ログイン処理後に一覧ページにリダイレクトするようにしました。
- ヘッダーのログイン導線を削除しました。


# やっていないこと
テストのリファクタリングはしてません。
（他とまとめてやりたいので別PRにします。なので重複コードがちょっと目立つ・・）

# 見てほしいところ・注意してほしいところなど
ログインページの文言見てほしいです。ライティング苦手。