### PR TITLE
自動ビルドの復旧

### DIFF
--- a/.github/workflows/docker_build_amd.yml
+++ b/.github/workflows/docker_build_amd.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           push: true
           platforms: linux/amd64
+          build-args: credential_key=${{ secrets.RAILS_MASTER_KEY_DEV }}
           tags: chiroruxx/aiit_student_profule:amd-${{ github.sha }},chiroruxx/aiit_student_profule:amd-latest
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache-amd

--- a/.github/workflows/docker_build_arm.yml
+++ b/.github/workflows/docker_build_arm.yml
@@ -39,7 +39,9 @@ jobs:
         with:
           push: true
           platforms: linux/arm64
-          build-args: lockfile=Gemfile.lock.m1
+          build-args: |
+            lockfile=Gemfile.lock.m1
+            credential_key=${{ secrets.RAILS_MASTER_KEY_DEV }}
           tags: chiroruxx/aiit_student_profule:arm-${{ github.sha }},chiroruxx/aiit_student_profule:arm-latest
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache-arm

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM ruby:2.7
 
 ARG lockfile="Gemfile.lock"
+ARG credential_key=""
+
+ENV RAILS_MASTER_KEY=$credential_key
 
 RUN apt-get update && apt-get install -y curl apt-transport-https wget && \
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \


### PR DESCRIPTION
# 概要
自動ビルドが落ちていたので修正しました。

# やったこと
原因は鍵ファイルがないことでした。
なので、Docker image を作成する際に環境変数 `RAILS_MASTER_KEY` を設定するようにしました。
`RAILS_MASTER_KEY` があると、鍵ファイルではなくこの環境変数を参照するようになります。
鍵情報はバージョン管理されていないため、GitHubのSecretsに情報を登録し、それをDockerfileに引き渡しています。

# やっていないこと

# 見てほしいところ・注意してほしいところなど
