### PR TITLE
アカウント作成時にメールアドレスが設定されないバグを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
         name: auth_hash.info.name,
         provider: auth_hash.provider,
         uid: auth_hash.uid,
-        email: auth_hash.uid,
+        email: auth_hash.info.email,
         image: auth_hash.info.image
       }
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,9 +17,9 @@ module ActiveSupport
       OmniAuth::AuthHash.new({
                                provider: user.provider,
                                uid: user.uid,
-                               email: user.email,
                                info: {
                                  name: user.name,
+                                 email: user.email,
                                  image: user.image
                                }
                              })
@@ -29,9 +29,9 @@ module ActiveSupport
       OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
                                                                            provider: 'google_oauth2',
                                                                            uid: '12345678910',
-                                                                           email: 'mock@example.com',
                                                                            info: {
                                                                              name: 'mockuser',
+                                                                             email: 'mock@example.com',
                                                                              image: 'https://test.com/test.png'
                                                                            }
                                                                          })


### PR DESCRIPTION
# 概要
fixed #75 

アカウント作成時に `email` カラムに uid が設定されていたのをメールアドレスに変更しました。

# やったこと
概要と同じ

# やっていないこと

# 見てほしいところ・注意してほしいところなど
