### PR TITLE
一覧ページの画像をログイン時のものに差し替え

### DIFF
--- a/app/javascript/styles/user_profiles.scss
+++ b/app/javascript/styles/user_profiles.scss
@@ -19,12 +19,16 @@
     }
     &__photo {
       width: 80px;
-      height: 90px;
+      height: 80px;
       margin: 10px;
       grid-gap: 4rem;
       flex-flow: column nowrap;
       justify-content: flex-end;
       background-color: white;
+
+      &.material-icons {
+        font-size: 80px;
+      }
     }
     &__info {
       padding: 0.5rem;

--- a/app/views/user_profiles/index.html.erb
+++ b/app/views/user_profiles/index.html.erb
@@ -4,8 +4,11 @@
   <% @user_profiles.each do |user_profile| %>
     <li class="bg-palegreen user_profile">
       <a href="<%= profile_path(user_profile) %>">
-        <%# ユーザーアイコン登録実装後差し替える %>
-        <img src="https://1.bp.blogspot.com/-3YfJ5FDIfB0/Wn1V7_0bdfI/AAAAAAABKGc/NJMDAsrSGBEkWEpaxBjBujsXHqOXEx3pACLcBGAs/s400/hyoujou_shinda_me_man.png" alt="" class="user_profile__photo">
+        <% if user_profile.user.image.present? %>
+          <img src="<%= user_profile.user.image %>" alt="" class="user_profile__photo">
+        <% else %>
+          <span class="material-icons user_profile__photo">account_box</span>
+        <% end %>
         <div class="user_profile__info">
           <span class="username"><%= user_profile.name %></span>
           <span class="major_subject">

--- a/test/integration/user_profiles_index_test.rb
+++ b/test/integration/user_profiles_index_test.rb
@@ -25,6 +25,11 @@ class UserProfilesIndexTest < ActionDispatch::IntegrationTest
         assert_select 'span.username', text: user_profiles[i].name
         assert_select 'span.major_subject_name', text: user_profiles[i].major_subject
         assert_select 'span.other', text: user_profiles[i].other.truncate(200) if user_profiles[i].other.present?
+        next unless user_profiles[i].user.image.present?
+
+        assert_select 'img' do
+          assert_select '[src=?]', user_profiles[i].user.image
+        end
       end
     end
   end


### PR DESCRIPTION
# 概要
fixed #49 

一覧ページのプロフ画像をダミーのものから差し替えました。

# やったこと
- 画像がある場合はその画像を、ない場合はアイコンを出すようにしました。
- 画像が縦長になっていたので、縦横同じサイズに修正しました。
- テストを追記しました。

# やっていないこと
特になし

# 見てほしいところ・注意してほしいところなど