### PR TITLE
エラーページの「トップに戻る」の遷移先を設定

### DIFF
--- a/app/views/errors/default.html.erb
+++ b/app/views/errors/default.html.erb
@@ -4,6 +4,6 @@
   <div class="error__container container">
     <h1 class="error__title"><span class="material-icons">new_releases</span>Oops!</h1>
     <p><%= @message %></p>
-    <a class="btn btn-primary btn-lg top_button" href="<%# route('home') %>" role="button">トップへ戻る</a>
+    <a class="btn btn-primary btn-lg top_button" href="<%= root_path %>" role="button">トップへ戻る</a>
   </div>
 </div>


### PR DESCRIPTION
# 概要
(関連するIssueがあればリンクを貼る)
#65

エラーページの「トップに戻る」の遷移先をトップページに設定する。

# やったこと
このPRで行ったこと
トップに戻るのリンクをroot_pathに設定

# やっていないこと
このPRで行っていないこと(Issue を作成してリンクを貼るとなお良し)
テストが書けていない。いま書いているところ

# 見てほしいところ・注意してほしいところなど
見てほしいところや注意してほしいところがあれば書く
特にない。

# ポンしたところ
リンクのところで`<% root_path %>`とイコールを入れずにやってハマった。