### PR TITLE
ローカル環境でテストが動かない問題を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ FROM ruby:2.7
 ARG lockfile="Gemfile.lock"
 ARG credential_key=""
 
-ENV RAILS_MASTER_KEY=$credential_key
-
 RUN apt-get update && apt-get install -y curl apt-transport-https wget && \
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
@@ -20,7 +18,9 @@ COPY . /profile_app
 COPY $lockfile /profile_app/Gemfile.lock
 
 RUN yarn install --check-files
-RUN bundle exec rails webpacker:compile
+RUN RAILS_MASTER_KEY=$credential_key && \
+    bundle exec rails webpacker:compile && \
+    unset RAILS_MASTER_KEY
 
 # Add a script to be executed every time the container starts.
 COPY entrypoint.sh /usr/bin/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Create database:
 $ docker-compose run web rake db:create
 ```
 
+### Optional
+ローカルで自分でビルドしたい場合は `docker-compose.yml` を以下のように編集し、
+
+```diff
+-     image: chiroruxx/aiit_student_profule:${CPU}-latest
++     build: .
+```
+
+以下のコマンドを実行することでビルドできます。
+
+```shell
+docker-compose build --build-arg credential_key=your_dev_credential_key
+```
+
+`your_dev_credential_key` のところには、自身のローカルのキーファイルの内容を入れてください。
+
 ## References
 
 - [Production](https://aiit-student-profile.herokuapp.com/)


### PR DESCRIPTION
# 概要
ローカル環境でテストが動かない問題を修正しました。

# やったこと
Dockerコンテナが 開発環境用の環境変数`RAILS_MASTER_KEY` を持っており、テスト実行時に復号できなくなっていたのが原因でした。(テスト環境用の鍵を渡さないといけない)

ローカルでは開発環境とテスト環境の両方で動くため、この環境変数を設定しないようにしました。

また、README にローカルでのビルド方法を記載しました。

# やっていないこと
なし

# 見てほしいところ・注意してほしいところなど
