### PR TITLE
added aiit.ac.jp domain のみを許可

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,10 @@ class SessionsController < ApplicationController
     email = auth_hash.info.email
     if !email.match?(/.*@aiit.ac.jp/)
       sign_out
-    elsif (user = User.find_or_create_from_auth_hash(auth_hash))
+      return redirect_to root_path, alert: '@aiit.ac.jp ドメインのみがログイン可能です。'
+    end
+
+    if (user = User.find_or_create_from_auth_hash(auth_hash))
       sign_in user
       return redirect_to profiles_path
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,6 @@ class SessionsController < ApplicationController
   def create
     email = auth_hash.info.email
     unless email.match?(/.*@aiit.ac.jp/)
-      sign_out
       return redirect_to root_path, alert: '@aiit.ac.jp ドメインのみがログイン可能です。'
     end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,9 +6,7 @@ class SessionsController < ApplicationController
 
   def create
     email = auth_hash.info.email
-    unless email.match?(/.*@aiit.ac.jp/)
-      return redirect_to root_path, alert: '@aiit.ac.jp ドメインのみがログイン可能です。'
-    end
+    return redirect_to root_path, alert: '@aiit.ac.jp ドメインのみがログイン可能です。' unless email.match?(/.*@aiit.ac.jp/)
 
     if (user = User.find_or_create_from_auth_hash(auth_hash))
       sign_in user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,10 @@ class SessionsController < ApplicationController
   skip_before_action :signed_in, only: :create
 
   def create
-    if (user = User.find_or_create_from_auth_hash(auth_hash))
+    email = auth_hash.info.email
+    if !email.match?(/.*@aiit.ac.jp/)
+      sign_out
+    elsif (user = User.find_or_create_from_auth_hash(auth_hash))
       sign_in user
     end
     redirect_to root_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
 
   def create
     email = auth_hash.info.email
-    if !email.match?(/.*@aiit.ac.jp/)
+    unless email.match?(/.*@aiit.ac.jp/)
       sign_out
       return redirect_to root_path, alert: '@aiit.ac.jp ドメインのみがログイン可能です。'
     end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,11 @@
 <div class="top">
   <div class="top__container container">
     <h1 class="top__title">AIIT Student Profile</h1>
+    <% if alert %>
+      <div class="alert alert-danger" role="alert">
+        <%= alert %>
+      </div>
+    <% end %>
     <p class="top__description">
       AIIT Student Profile は簡単にプロフィールを作成できるサービスです。<br>
       グループワークでの自己紹介タイムで簡単にわかりやすく自己紹介ができます。

--- a/test/controllers/session_controller_test.rb
+++ b/test/controllers/session_controller_test.rb
@@ -26,9 +26,9 @@ class SessionControllerTest < ActionDispatch::IntegrationTest
       uid: '9999999999',
       name: 'mockuser',
       email: 'mock@example.com',
-      image: 'https://test.com/test.png'      
+      image: 'https://test.com/test.png'
     }
-    
+
     setup_mock User.new(user)
 
     get '/auth/:provider/callback'

--- a/test/controllers/session_controller_test.rb
+++ b/test/controllers/session_controller_test.rb
@@ -89,7 +89,7 @@ class SessionControllerTest < ActionDispatch::IntegrationTest
       provider: 'google_oauth2',
       uid: '9999999999',
       name: 'mockuser',
-      email: 'mock@example.com',
+      email: 'mock@aiit.ac.jp',
       image: 'https://test.com/test.png'
     }
 

--- a/test/controllers/session_controller_test.rb
+++ b/test/controllers/session_controller_test.rb
@@ -20,6 +20,22 @@ class SessionControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to profiles_path
   end
 
+  test 'Redirect when invalid email' do
+    user = {
+      provider: 'google_oauth2',
+      uid: '9999999999',
+      name: 'mockuser',
+      email: 'mock@example.com',
+      image: 'https://test.com/test.png'      
+    }
+    
+    setup_mock User.new(user)
+
+    get '/auth/:provider/callback'
+
+    assert_redirected_to root_path
+  end
+
   test 'Save user data if user have not logged in' do
     # clean up
     User.find_by(provider: 'google_oauth2', uid: '9999999999', &:destroy)

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -9,7 +9,7 @@ one:
   provider: google_oauth2
   name: Taro Yamada
   uid: 100000000000000000000
-  email: taro@example.com
+  email: taro_test@aiit.ac.jp
   image: https://example.com
 
 two:
@@ -17,21 +17,21 @@ two:
   provider: Google
   name: Hanako Satoh
   uid: 100000000000000000001
-  email: hanako@example.com
+  email: hanako_test@aiit.ac.jp
 
 three:
   id: 3
   provider: Google
   name: Kiyomi Oyama
   uid: 100000000000000000002
-  email: oyama_kiyomi_test@example.com
+  email: oyama_kiyomi_test@aiit.ac.jp
 
 four:
   id: 4
   provider: Google
   name: xxxx
   uid: 100000000000000000003
-  email: xxxx@example.com
+  email: xxxx@aiit.ac.jp
 
 <% (100..121).each do |idx| %> 
 user_<%= idx %>:
@@ -39,5 +39,5 @@ user_<%= idx %>:
   provider: Google
   name: 'mockuser'
   uid: 12345678910,
-  email: mock@example.com
+  email: mock@aiit.ac.jp
 <% end %>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ module ActiveSupport
                                                                            uid: '12345678910',
                                                                            info: {
                                                                              name: 'mockuser',
-                                                                             email: 'mock@example.com',
+                                                                             email: 'mock@aiit.ac.jp',
                                                                              image: 'https://test.com/test.png'
                                                                            }
                                                                          })


### PR DESCRIPTION
# 概要
- #7 
- #88 

ログイン時、`aiit.ac.jp` ドメイン以外の場合はトップページにリダイレクトし、メッセージを表示させました。
※ スクリーンショット撮れなくて画像なし。

# やったこと

- セッション create 時に `aiit.ac.jp` ドメイン以外の制御を追加。index にリダイレクト。
- index にエラーメッセージを表示。
- 正常系テストで利用しているメールアドレスを `aiit.ac.jp` に変更。


# やっていないこと

# 見てほしいところ・注意してほしいところなど

- ログイン時にエラーとする場合の画面遷移およびメッセージはこれで構わないか。
- alert メッセージのデザイン